### PR TITLE
Remove usage of User.trackCount

### DIFF
--- a/match.py
+++ b/match.py
@@ -194,7 +194,7 @@ def search_queries(track):
                       replace_non_alphanumeric(track.album))))
 
 
-def match_tracks(rdio_tracks, play_music, num_tracks=None):
+def match_tracks(rdio_tracks, play_music, num_tracks='?'):
     """
     :type rdio_tracks List[rdio.RdioTrack]
     :type num_tracks int
@@ -225,10 +225,9 @@ def match_tracks(rdio_tracks, play_music, num_tracks=None):
         else:
             unmatched_missing += 1
         count += 1
-        if num_tracks:
+        if num_tracks != '?':
             percentage = int(100 * count / float(num_tracks))
         else:
-            num_tracks = '?'
             percentage = '?'
         sys.stdout.write(' % 6d/%r scanned % 2r%%. %d matched, %d unmatched, %d unmatched but unavailable on Rdio\r' % (
             count, num_tracks, percentage, matched, unmatched, unmatched_missing))

--- a/match.py
+++ b/match.py
@@ -194,7 +194,7 @@ def search_queries(track):
                       replace_non_alphanumeric(track.album))))
 
 
-def match_tracks(rdio_tracks, num_tracks, play_music):
+def match_tracks(rdio_tracks, play_music, num_tracks=None):
     """
     :type rdio_tracks List[rdio.RdioTrack]
     :type num_tracks int
@@ -225,8 +225,12 @@ def match_tracks(rdio_tracks, num_tracks, play_music):
         else:
             unmatched_missing += 1
         count += 1
-        percentage = int(100 * count / float(num_tracks))
-        sys.stdout.write(' % 6d/%d scanned % 2d%%. %d matched, %d unmatched, %d unmatched but unavailable on Rdio\r' % (
+        if num_tracks:
+            percentage = int(100 * count / float(num_tracks))
+        else:
+            num_tracks = '?'
+            percentage = '?'
+        sys.stdout.write(' % 6d/%r scanned % 2r%%. %d matched, %d unmatched, %d unmatched but unavailable on Rdio\r' % (
             count, num_tracks, percentage, matched, unmatched, unmatched_missing))
         sys.stdout.flush()
     sys.stdout.write('\n')

--- a/rdio-export.py
+++ b/rdio-export.py
@@ -56,7 +56,7 @@ def migrate_playlist(user_key, playlist):
         print u'Can\'t get tracks for playlist "%s" - it might be private.' % playlist['name']
         return
     with Report('playlist-%s.html' % playlist['key'], name) as report:
-        for match in match_tracks(tracks, len(tracks), pm):
+        for match in match_tracks(tracks, pm, len(tracks)):
             report.add_match(match)
             if match.matched():
                 play_track_ids.append(match.play.id)
@@ -73,7 +73,7 @@ def migrate_playlist(user_key, playlist):
 
 def migrate_playlists(rdio_username):
     print 'Finding playlists...'
-    user = rdio.call('findUser', vanityName=rdio_username, extras='trackCount')
+    user = rdio.call('findUser', vanityName=rdio_username)
     user_key = user['key']
     playlists = {}
     for kind in ('owned', 'collab', 'favorites', 'subscribed'):
@@ -101,12 +101,12 @@ def migrate_playlists(rdio_username):
 
 
 def migrate_favorites(rdio_username):
-    user = rdio.call('findUser', vanityName=rdio_username, extras='trackCount')
-    print 'Migrating %(trackCount)d favorites for %(firstName)s %(lastName)s' % user
+    user = rdio.call('findUser', vanityName=rdio_username)
+    print 'Migrating favorites for %(firstName)s %(lastName)s' % user
 
     rdio_tracks = rdio.favorite_tracks(user['key'])
     with Report('favorites.html', "%(firstName)s %(lastName)s's Favorites" % user) as report:
-        matched_tracks = match_tracks(rdio_tracks, user['trackCount'], pm)
+        matched_tracks = match_tracks(rdio_tracks, pm)
         for match in matched_tracks:
             report.add_match(match)
             if match.matched():


### PR DESCRIPTION
User.trackCount is an old deprecated field that now returns 0 for most users, regardless of their favorites.  The proper way to get a Favorites count from the API is to use a more recent API version and take the 'total' value from the `getFavorites` API result, but that's fairly complicated and IMO the count is not that important to have here.
